### PR TITLE
Add support for runtime registration/removal of entities and fixes max volume controller range

### DIFF
--- a/entities/entity.cpp
+++ b/entities/entity.cpp
@@ -168,6 +168,32 @@ void Entity::sendRegistration()
     }
 }
 
+//================ Code to allow runtime adding/removing of entities =======================//
+void Entity::runtimeRegistration()
+{
+    if (HaControl::mqttClient()->state() != QMqttClient::Connected) {
+        return;
+    }
+    
+    qCDebug(base) << "Runtime registration of entity:" << id() << "(" << name() << ")";
+    init();
+
+}
+
+void Entity::unRegister()
+{
+    if (HaControl::mqttClient()->state() != QMqttClient::Connected) {
+        qCWarning(base) << "Cannot unregister entity" << id() << "(" << name() << ")" 
+                        << "- MQTT client not connected";
+        return;
+    }
+    
+    qCDebug(base) << "Unregistering entity:" << id() << "(" << name() << ")";
+    HaControl::mqttClient()->publish(discoveryPrefix() + "/" + haType() + "/" + hostname() + "/" + id() + "/config",
+    QByteArray(), 0,true);
+}
+
+
 void Entity::setAttributes(const QVariantMap &attrs)
 {
     m_attributes = attrs;

--- a/entities/entity.cpp
+++ b/entities/entity.cpp
@@ -189,7 +189,7 @@ void Entity::unRegister()
     }
     
     qCDebug(base) << "Unregistering entity:" << id() << "(" << name() << ")";
-    HaControl::mqttClient()->publish(discoveryPrefix() + "/" + haType() + "/" + hostname() + "/" + id() + "/config",
+    HaControl::mqttClient()->publish(s_discoveryPrefix + "/" + haType() + "/" + hostname() + "/" + id() + "/config",
     QByteArray(), 0,true);
 }
 

--- a/entities/entity.h
+++ b/entities/entity.h
@@ -158,7 +158,17 @@ public:
      * multiple systems on the same network.
      */
     QString hostname() const;
+
     
+    /**
+     * @brief Registers this entity with Home Assistant via MQTT at runtime
+     */
+    void runtimeRegistration();
+
+    /**
+     * @brief Unregisters this entity from Home Assistant
+     */
+    void unRegister();
     /**
      * @brief Constructs the base MQTT topic for this entity
      * @return QString Full MQTT topic path

--- a/entities/number.cpp
+++ b/entities/number.cpp
@@ -58,6 +58,16 @@ void Number::setValue(int value)
     }
 }
 
+int Number::min()
+{
+    return  m_min;
+}
+
+int Number::max()
+{
+    return  m_max;
+}
+
 int Number::value()
 {
     return m_value;

--- a/entities/number.h
+++ b/entities/number.h
@@ -13,6 +13,10 @@ public:
     int value();
     // Optional customization for integrations before init()
     void setRange(int min, int max, int step = 1, const QString &unit = "%");
+    //returns the max value set
+    int max();
+    //returns the min value set
+    int min();
 
 protected:
     void init() override;

--- a/integrations/audio.cpp
+++ b/integrations/audio.cpp
@@ -39,6 +39,7 @@ private slots:
 
 private:
     bool checkIfRaiseMaxVolumeEnabled();
+    bool raiseMaximumVolumeEnabled = false;
     int paToPercent(qint64 v) const;
     qint64 percentToPa(int percent) const;
 
@@ -61,7 +62,8 @@ Audio::Audio(QObject *parent)
     m_sinkVolume->setId("output_volume");
     m_sinkVolume->setName("Output Volume");
     m_sinkVolume->setDiscoveryConfig("icon", "mdi:knob");
-    if(checkIfRaiseMaxVolumeEnabled())
+    raiseMaximumVolumeEnabled = checkIfRaiseMaxVolumeEnabled();
+    if (raiseMaximumVolumeEnabled)
         m_sinkVolume->setRange(0, 150, 1, "%");
     else
         m_sinkVolume->setRange(0, 100, 1, "%");
@@ -78,8 +80,8 @@ Audio::Audio(QObject *parent)
                 this->watcher->addPath(configPath);
             }
             if (QFile::exists(configPath)) {
-                bool enabled = checkIfRaiseMaxVolumeEnabled();
-                m_sinkVolume->setRange(0, enabled ? 150 : 100, 1, "%");
+                raiseMaximumVolumeEnabled = checkIfRaiseMaxVolumeEnabled();
+                m_sinkVolume->setRange(0, raiseMaximumVolumeEnabled ? 150 : 100, 1, "%");
                 m_sinkVolume->runtimeRegistration();
             }
         });
@@ -221,7 +223,22 @@ void Audio::onSinkVolumeChanged()
     int percent = paToPercent(m_sink->volume());
     if (percent == m_sinkVolume->value())
         return;
-
+    int currentMax = m_sinkVolume->max();
+    if(percent > 100 && currentMax == 100)
+    {
+        m_sinkVolume->setRange(0, 150, 1, "%");
+        m_sinkVolume->runtimeRegistration();
+    }
+    else if (percent <= 100 && currentMax == 150 && !raiseMaximumVolumeEnabled)
+    {
+        m_sinkVolume->setRange(0, 100, 1, "%");
+        m_sinkVolume->runtimeRegistration();       
+    }
+    if(percent > 150)
+    {
+        qCCritical(audio) << "Volume above 150% is not supported by kiot, you are trying to use" << percent << "%, if you want to blow the speaker, please change the source yourself";
+        return;
+    }
     m_sinkVolume->setValue(percent);
     qCDebug(audio) << "Updated volume from system:" << percent << "%";
 }

--- a/integrations/audio.cpp
+++ b/integrations/audio.cpp
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include "core.h"
-#include "entities/entities.h"
+#include "entities/number.h"
+#include "entities/select.h"
 
 #include <PulseAudioQt/Context>
 #include <PulseAudioQt/Server>
@@ -10,10 +11,12 @@
 #include <PulseAudioQt/Source>
 #include <PulseAudioQt/VolumeObject>
 
+#include <QFileSystemWatcher>
+#include <QFile>
+#include <QDir>
 #include <QLoggingCategory>
 Q_DECLARE_LOGGING_CATEGORY(audio)
-Q_LOGGING_CATEGORY(audio, "integration.Audio")
-
+Q_LOGGING_CATEGORY(audio, "integrations.Audio")
 
 class Audio : public QObject
 {
@@ -32,11 +35,14 @@ private slots:
 
     void setSinkVolume(int v);
     void setSourceVolume(int v);
+    
 
 private:
+    bool checkIfRaiseMaxVolumeEnabled();
     int paToPercent(qint64 v) const;
     qint64 percentToPa(int percent) const;
 
+    QFileSystemWatcher *watcher = nullptr;
     Number *m_sinkVolume = nullptr;
     Number *m_sourceVolume = nullptr;
     Select *m_sinkSelector = nullptr;
@@ -55,10 +61,29 @@ Audio::Audio(QObject *parent)
     m_sinkVolume->setId("output_volume");
     m_sinkVolume->setName("Output Volume");
     m_sinkVolume->setDiscoveryConfig("icon", "mdi:knob");
-    m_sinkVolume->setRange(0, 100, 1, "%");
-
+    if(checkIfRaiseMaxVolumeEnabled())
+        m_sinkVolume->setRange(0, 150, 1, "%");
+    else
+        m_sinkVolume->setRange(0, 100, 1, "%");
+    
     connect(m_sinkVolume, &Number::valueChangeRequested, this, &Audio::setSinkVolume);
 
+    QString configPath = QDir::homePath() + "/.config/plasmaparc";
+    if (QFile::exists(configPath))
+    {
+        watcher = new QFileSystemWatcher(this);
+        watcher->addPath(configPath);
+        connect(watcher, &QFileSystemWatcher::fileChanged, this, [this,configPath](const QString &){
+            if (!this->watcher->files().contains(configPath)) {
+                this->watcher->addPath(configPath);
+            }
+            if (QFile::exists(configPath)) {
+                bool enabled = checkIfRaiseMaxVolumeEnabled();
+                m_sinkVolume->setRange(0, enabled ? 150 : 100, 1, "%");
+                m_sinkVolume->runtimeRegistration();
+            }
+        });
+    }
     m_sourceVolume = new Number(this);
     m_sourceVolume->setId("input_volume");
     m_sourceVolume->setName("Input Volume");
@@ -236,7 +261,26 @@ void Audio::setSourceVolume(int v)
     m_source->setVolume(paVol);
     qCDebug(audio) << "Set volume to" << v << "%";
 }
+bool Audio::checkIfRaiseMaxVolumeEnabled()
+{
+    // Universal path til alle brukere
+    QString path = QStringLiteral("%1/.config/plasmaparc").arg(qgetenv("HOME"));
+    QFile file(path);
 
+    if (!file.exists() || !file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return false; // fil finnes ikke eller kan ikke åpnes
+    }
+
+    QTextStream in(&file);
+    while (!in.atEnd()) {
+        QString line = in.readLine().trimmed();
+        if (line == QLatin1String("RaiseMaximumVolume=true")) {
+            return true;
+        }
+    }
+
+    return false;
+}
 int Audio::paToPercent(qint64 v) const
 {
     double p = (double)v / PulseAudioQt::normalVolume() * 100.0;


### PR DESCRIPTION
This PR introduces several improvements to the Kiot entity system and the Audio integration:

- Runtime registration/removal for entities – two new functions in entity.cpp allow entities to be registered or removed at runtime. This enables dynamic updates, such as adjusting volume ranges or other attributes while the system is running.

- Dynamic volume range based on “RaiseMaximumVolume” – Audio now checks the user’s RaiseMaximumVolume setting and updates the Number entity range (0–100 % or 0–150 %) accordingly.

- QFileSystemWatcher integration – the Audio integration watches the ~/.config/plasmaparc file for changes to RaiseMaximumVolume, and automatically updates the cached value and re-registers the entity with MQTT when the range changes.

- Edge-case handling for CLI / pactl volume changes – dynamic range adjustment ensures that volumes above 100 % are supported correctly without breaking the entity or causing desync with Home Assistant. Volumes above 150 % are clamped and logged as critical.

This resolves the issue reported in [#81](https://github.com/davidedmundson/kiot/issues/81)
 by making the Audio integration robust against runtime changes and supporting both normal users and advanced edge cases.
 
Note:
We use `QFileSystemWatcher` to parse the config file line by line for the `RaiseMaximumVolume` entry. When the setting is disabled via System Settings, the entry is removed entirely instead of being set to false. It’s unclear if `KConfigWatcher` can reliably monitor non-existing entries, so using `QFileSystemWatcher` ensures correct caching and runtime updates in all cases.