### PR TITLE
AccentColour: Rewrite watcher to reliably read KDE accent colors

### DIFF
--- a/integrations/accentcolour.cpp
+++ b/integrations/accentcolour.cpp
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include "core.h"
-#include "entities/entities.h"
-#include <QCoreApplication>
-
-#include <KConfigGroup>
-#include <KConfigWatcher>
-#include <KSharedConfig>
+#include "entities/sensor.h"
+#include <QApplication>
+#include <QFile>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QFileSystemWatcher>
+#include <QFileInfo>
+#include <QLoggingCategory>
+Q_DECLARE_LOGGING_CATEGORY(ac)
+Q_LOGGING_CATEGORY(ac,  "integrations.AccentColour")
 
 class AccentColourWatcher : public QObject
 {
@@ -19,24 +23,114 @@ public:
         auto sensor = new Sensor(this);
         sensor->setId("accentcolor");
         sensor->setName("Accent Color");
+        sensor->setDiscoveryConfig("icon","mdi:format-color-fill");
 
-        // it's in kdeglobals
-        KConfigGroup config(KSharedConfig::openConfig()->group("General"));
-        sensor->setState(config.readEntry("AccentColor")); // if not custom, then we should find out the default from the theme?
+        // Load initial state
+        updateAccentColor(sensor);
 
-        m_watcher = KConfigWatcher::create(KSharedConfig::openConfig());
-
-        QObject::connect(m_watcher.data(), &KConfigWatcher::configChanged, this, [sensor](const KConfigGroup &group) {
-            if (group.name() != "General") {
-                return;
-            }
-            // this is in the format "r,g,b" as numbers. Will need some conversion HA side to do anything useful with it
-            sensor->setState(group.readEntry("AccentColor"));
-        });
+        // Set up file watching (different for Flatpak vs native)
+        setupFileWatching(sensor);
     }
 
 private:
-    KConfigWatcher::Ptr m_watcher;
+    void setupFileWatching(Sensor *sensor) {
+
+        QString configPath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.config/kdeglobals";
+        m_fileWatcher = new QFileSystemWatcher(this);
+        m_fileWatcher->addPath(configPath);
+        qCDebug(ac) << "Watching file:" << configPath;
+        connect(m_fileWatcher, &QFileSystemWatcher::fileChanged, this, 
+            [this, sensor, configPath](const QString &path) {
+                qCDebug(ac) << "File changed:" << path;
+                updateAccentColor(sensor);
+                // TODO figure out why we need to do this to get updates after first change
+                m_fileWatcher->removePath(configPath);
+                m_fileWatcher->addPath(configPath);
+            });
+    }
+
+    void updateAccentColor(Sensor *sensor) {
+        
+        QString configPath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.config/kdeglobals";
+        if(!QFile::exists(configPath)) {
+            return;
+        }
+        QSettings settings(configPath, QSettings::IniFormat);
+
+
+        QString accentColor = settings.value("AccentColor","").toString();
+        QString lastUsedColor = settings.value("LastUsedCustomAccentColor","").toString();
+        bool fromWallpaper = settings.value("accentColorFromWallpaper", false).toBool();
+        
+        QVariantMap attributes;
+        
+        // Set main state
+        if (!accentColor.isEmpty()) {
+            sensor->setState(rgbToHex(accentColor));
+            attributes["has_accent"] = true;
+            attributes["source"] = fromWallpaper ? "wallpaper" : "custom";
+            setRgbAttributes(attributes, accentColor, "current");
+        } else {
+            // No accent color set (using theme default)
+            sensor->setState("theme_default");
+            attributes["has_accent"] = false;
+            attributes["source"] = "theme";
+            // Use KDE's default blue as fallback in attributes
+            // TODO find theme colors from theme
+            attributes["theme_default_color"] = "#3DAEE9";
+            attributes["theme_default_rgb"] = "61,174,233";
+        }
+        
+        // Always include last used custom color (if exists)
+        if (!lastUsedColor.isEmpty()) {
+            attributes["last_used_custom_hex"] = rgbToHex(lastUsedColor);
+            setRgbAttributes(attributes, lastUsedColor, "last_used");
+        }
+        
+        // Add from_wallpaper flag
+        attributes["from_wallpaper"] = fromWallpaper;
+        
+        sensor->setAttributes(attributes);
+    }
+
+    QString rgbToHex(const QString &rgb) {
+        QStringList parts = rgb.split(",");
+        if (parts.size() != 3) return rgb;
+        
+        bool ok;
+        int r = parts[0].toInt(&ok);
+        if (!ok || r < 0 || r > 255) return rgb;
+        int g = parts[1].toInt(&ok);
+        if (!ok || g < 0 || g > 255) return rgb;
+        int b = parts[2].toInt(&ok);
+        if (!ok || b < 0 || b > 255) return rgb;
+        
+        return QString("#%1%2%3")
+            .arg(r, 2, 16, QChar('0'))
+            .arg(g, 2, 16, QChar('0'))
+            .arg(b, 2, 16, QChar('0'));
+    }
+    
+    void setRgbAttributes(QVariantMap &attributes, const QString &rgb, const QString &prefix) {
+        QStringList parts = rgb.split(",");
+        if (parts.size() == 3) {
+            bool ok;
+            int r = parts[0].toInt(&ok);
+            int g = ok ? parts[1].toInt(&ok) : 0;
+            int b = ok ? parts[2].toInt(&ok) : 0;
+            
+            if (ok) {
+                QString attrPrefix = prefix.isEmpty() ? "" : prefix + "_";
+                attributes[attrPrefix + "red"] = r;
+                attributes[attrPrefix + "green"] = g;
+                attributes[attrPrefix + "blue"] = b;
+                attributes[attrPrefix + "rgb"] = QString("%1,%2,%3").arg(r).arg(g).arg(b);
+            }
+        }
+    }
+
+
+    QFileSystemWatcher *m_fileWatcher = nullptr;
 };
 
 void setupAccentColour()


### PR DESCRIPTION
The previous implementation relied on KConfigWatcher,  and never gave any value when missing the AccentColor entry in kdeglobals. 

This rewrite:
- Reads AccentColor, LastUsedCustomAccentColor, and accentColorFromWallpaper directly from ~/.config/kdeglobals using QSettings.
- Converts RGB strings to hex for Home Assistant state.
- Adds detailed attributes for current, last used, and theme default colors.
- Uses QFileSystemWatcher for reliable live updates on file changes.
- Provides fallback for theme default color to ensure the sensor always reports a value.

This ensures the AccentColour integration works reliably for both native and Flatpak KDE and for users without an AccentColor entry in their config file, while providing meaningful sensor data to Home Assistant.


Can KConfigWatcher listen for file changes instead of just variable changes? 
I went with QFileSystemWatcher since i needed this feature and could not find information about doing this with KConfigWatcher