### PR TITLE
Add helper scripts to streamline environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ build/
 CMakeLists.txt.user
 backups/
 kiot.code-workspace
-scripts/
 *.sh
 flatpak-repo
+.directory

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ build/
 CMakeLists.txt.user
 backups/
 kiot.code-workspace
-*.sh
 flatpak-repo
 .directory

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   - [Configuration Examples](#configuration-examples)
 - [Supported Features](#supported-features)
 - [Flatpak Build](#flatpak-build)
-   - [Quick Install](#quick-Install)
+   - [Quick Install](#quick-build)
    - [Manual Install](#manual-build)
 - [Future Development](#future-development)
 - [Contributing](#contributing)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Navigation
 - [About](#about)
 - [Setup](#setup)
+  - [Recommended Setup (Helper Script)](#recommended-setup-helper-script)
   - [Dependencies](#dependencies)
   - [Download and Install](#download-and-install)
 - [Configuration](#configuration)
@@ -10,6 +11,8 @@
   - [Configuration Examples](#configuration-examples)
 - [Supported Features](#supported-features)
 - [Flatpak Build](#flatpak-build)
+   - [Quick Install](#quick-Install)
+   - [Manual Install](#manual-build)
 - [Future Development](#future-development)
 - [Contributing](#contributing)
 - [Troubleshooting](#troubleshooting)
@@ -34,6 +37,15 @@ This is pre-alpha software suitable for users comfortable with:
 - Testing early-stage software
 
 ## Setup
+
+### Recommended Setup (Helper Script)
+
+The fastest way to install dependencies and build Kiot is using the interactive helper menu:
+
+```sh
+chmod +x helper.sh
+./helper.sh
+```
 
 ### Dependencies
 
@@ -199,6 +211,21 @@ Shortcuts=true
 ## Flatpak Build
 
 Flatpak installation is also supported:
+
+### Quick Build
+Run 
+```sh
+chmod +x helper.sh
+./helper.sh
+```
+Then select option `3` (Flatpak build and install menu). 
+In the next menu select option `1` (Build and Install as user)
+
+Or you can directly execute:
+```sh
+./scripts/flatpak.sh
+```
+### Manual build
 
 1. Clone this repository
 2. Run:

--- a/helper.sh
+++ b/helper.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_PATH="$SCRIPT_DIR/scripts"
+
+# Defensive sjekk: Finnes scripts-mappen i det hele tatt?
+if [ ! -d "$SCRIPTS_PATH" ]; then
+    echo "Error: Directory '$SCRIPTS_PATH' not found."
+    echo "Make sure you are running helper.sh from the root of the KIOT repository."
+    exit 1
+fi
+
+pause() {
+    echo
+    read -rp "Press Enter to return to menu..."
+}
+
+# Hjelpefunksjon som sjekker om skriptet eksisterer før kjøring
+run_script() {
+    local script_name="$1"
+    local full_path="$SCRIPTS_PATH/$script_name"
+
+    if [ -f "$full_path" ]; then
+        bash "$full_path"
+    else
+        echo "Error: Could not find script '$script_name' in $SCRIPTS_PATH"
+    fi
+}
+
+while true; do
+    clear
+    echo "======================================="
+    echo " KIOT Helper Menu"
+    echo "======================================="
+    echo
+    echo "0 Quit"
+    echo "1 Install dependencies (Arch/Debian, tested on Manjaro via pacman)"
+    echo "2 Native build and install menu"
+    echo "3 Flatpak build and install menu"
+    echo
+    echo "======================================="
+    read -rp "Select an option: " choice
+
+    case "$choice" in
+        0)
+            echo "Exiting."
+            exit 0
+            ;;
+        1)
+            echo "Installing dependencies..."
+            run_script "dependencies.sh"
+            pause
+            ;;
+        2)
+            echo "Opening Native build menu..."
+            run_script "native.sh"
+            pause
+            ;;
+        3)
+            echo "Opening Flatpak build menu..."
+            run_script "flatpak.sh"
+            pause
+            ;;
+        *)
+            echo "Invalid option."
+            sleep 1
+            ;;
+    esac
+done

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Dependency installer for Kiot
+# Tested on Manjaro KDE, CachyOS , with Debian/Ubuntu package names researched
+set -e
+
+# Detect package manager
+detect_pkg_manager() {
+    if command -v apt >/dev/null 2>&1; then
+        echo "apt"
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "pacman"
+    else
+        echo "unknown"
+    fi
+}
+
+# Install package
+install_package() {
+    local pkg="$1"
+    local pm=$(detect_pkg_manager)
+    if [ "$pm" = "apt" ]; then
+        if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+            sudo apt update
+            sudo apt install -y "$pkg"
+        fi
+    elif [ "$pm" = "pacman" ]; then
+        if ! pacman -Qi "$pkg" >/dev/null 2>&1; then
+            sudo pacman -S --noconfirm "$pkg"
+        fi
+    else
+        echo "Unsupported package manager"
+        exit 1
+    fi
+}
+
+echo "Installing system dependencies for Kiot..."
+
+PM=$(detect_pkg_manager)
+if [ "$PM" = "unknown" ]; then
+    echo "Cannot detect package manager. Aborting."
+    exit 1
+fi
+
+echo "Detected package manager: $PM"
+
+# Update system first
+if [ "$PM" = "apt" ]; then
+    sudo apt update
+elif [ "$PM" = "pacman" ]; then
+    sudo pacman -Sy
+fi
+
+# Core build tools (always needed)
+core_packages=(
+    cmake
+    extra-cmake-modules
+    git
+)
+
+# Qt6 dependencies
+qt6_packages=()
+
+# KDE Frameworks 6 dependencies
+kf6_packages=()
+
+# System libraries
+system_packages=()
+
+if [ "$PM" = "apt" ]; then
+    # Debian/Ubuntu package names
+    qt6_packages=(
+        qt6-base-dev
+        qt6-mqtt-dev
+        qt6-declarative-dev  # For QML if needed
+    )
+    
+    kf6_packages=(
+        libkf6config-dev
+        libkf6coreaddons-dev
+        libkf6dbusaddons-dev
+        libkf6notifications-dev
+        libkf6idletime-dev
+        libkf6globalaccel-dev
+        libkf6kcmutils-dev
+        libkf6i18n-dev
+        libkf6solid-dev
+        libkf6bluezqt-dev
+        libkf6pulseaudioqt-dev
+    )
+    
+    system_packages=(
+        libudev-dev          # For gamepad integration (libudev)
+        libsystemd-dev       # For systemd integration
+    )
+    
+elif [ "$PM" = "pacman" ]; then
+    # Arch/Manjaro package names
+    qt6_packages=(
+        qt6-base
+        qt6-mqtt
+        qt6-declarative      # For QML if needed
+    )
+    
+    kf6_packages=(
+        kconfig
+        kcoreaddons
+        kdbusaddons
+        knotifications
+        kidletime
+        kglobalaccel
+        kcmutils
+        ki18n
+        solid
+        bluez-qt
+        pulseaudio-qt
+    )
+    
+    system_packages=(
+        systemd-libs         # For udev and systemd
+    )
+fi
+
+echo "Installing core build tools..."
+for pkg in "${core_packages[@]}"; do
+    install_package "$pkg"
+done
+
+echo "Installing Qt6 dependencies..."
+for pkg in "${qt6_packages[@]}"; do
+    install_package "$pkg"
+done
+
+echo "Installing KDE Frameworks 6 dependencies..."
+for pkg in "${kf6_packages[@]}"; do
+    install_package "$pkg"
+done
+
+echo "Installing system libraries..."
+for pkg in "${system_packages[@]}"; do
+    install_package "$pkg"
+done
+
+# Special handling for qt6-mqtt on Debian/Ubuntu
+if [ "$PM" = "apt" ]; then
+    # Check if qt6-mqtt-dev is available
+    if ! apt-cache show qt6-mqtt-dev >/dev/null 2>&1; then
+        echo "Warning: qt6-mqtt-dev not found in repositories."
+        echo "You may need to install Qt6 MQTT module manually:"
+        echo "  Option 1: Build from source (https://github.com/qt/qtmqtt)"
+        echo "  Option 2: Use Qt Online Installer"
+        echo "  Option 3: Check if your distribution has it in a different repository"
+    fi
+fi
+
+echo ""
+echo "=========================================="
+echo "Dependency installation complete!"
+echo "=========================================="
+
+if [ "$PM" = "apt" ]; then
+    echo "Note for Debian/Ubuntu users:"
+    echo "  - qt6-mqtt-dev might not be available in all repositories"
+    echo "  - If missing, you'll need to build Qt MQTT from source"
+    echo "  - Visit: https://github.com/qt/qtmqtt for instructions"
+elif [ "$PM" = "pacman" ]; then
+    echo "All dependencies should now be installed."
+    echo "You can proceed to build Kiot with:"
+
+fi

--- a/scripts/flatpak.sh
+++ b/scripts/flatpak.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+#Grabs the flatpak id dynamic from the manifest with fallback to david
+FLATPAK_ID=$(grep -E '^id:' .flatpak-manifest.yaml | awk '{print $2}' | tr -d '"' | tr -d "'")
+
+# Hvis den feiler, sett en trygg fallback
+if [ -z "$FLATPAK_ID" ]; then
+    FLATPAK_ID="org.davidedmundson.kiot"
+fi
+
+
+pause() {
+    echo
+    read -rp "Press Enter to return to menu..."
+}
+
+build() {
+    if ! command -v flatpak-builder &> /dev/null; then
+        echo "Error: flatpak-builder is not installed. Please install it first."
+        return 0
+    fi
+    mkdir -p build
+    echo "Building flatpak bundle...."
+    flatpak-builder --repo=flatpak-repo --force-clean build-installer .flatpak-manifest.yaml 
+    echo "Building flatpak installer..........."
+    flatpak build-bundle flatpak-repo ./build/kiot.flatpak $FLATPAK_ID master
+    echo "installer buildt and located at ./build/kiot.flatpak"
+}
+
+cleanup() {
+    echo "Cleaning up files..."
+    rm -rf ./build-installer/
+    rm -rf ./flatpak-repo/
+}
+while true; do
+    echo "======================================="
+    echo " KIOT Flatpak Installer Menu"
+    echo "======================================="
+    echo
+    echo "0 Quit (runs a cleanup before closing)"
+    echo "1 Build and Install as user (--user flag, no sudo needed)"
+    echo "2 Uninstall as user (--user flag, no sudo needed)"
+    echo "3 Cleanup files"
+    echo
+    echo "======================================="
+    read -rp "Select an option: " choice
+
+    case "$choice" in
+        0)
+            echo "Exiting."
+            cleanup
+            exit 0
+            ;;
+        1)
+            build
+            echo "Installing kiot as user..."
+            flatpak install --user  -y ./build/kiot.flatpak
+            pause
+            ;;
+        2)
+            echo "Uninstalling kiot as user..."
+            flatpak uninstall --user  -y $FLATPAK_ID
+            pause
+            ;;
+        3)
+            echo "Deleting build and repo folders..."
+            cleanup
+            pause
+            ;;
+    esac
+done

--- a/scripts/native.sh
+++ b/scripts/native.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+pause() {
+    echo
+    read -rp "Press Enter to return to menu..."
+}
+
+cleanup() {
+    echo "Cleaning up build directory..."
+    rm -rf build
+}
+
+build() {
+    echo "Building kiot..."
+    mkdir -p build
+    cd build
+    cmake ..
+    make clean
+    # make clang-format
+    make
+    cd ..
+}
+
+install() {
+    echo "Installing kiot...(this requires sudo)"
+    cd build
+    sudo make install
+    cd ..
+}
+
+build_and_install() {
+    echo "Building and installing kiot..."
+    build
+    install
+}
+
+uninstall() {
+    echo "Uninstalling kiot...(this requires sudo)"
+    
+    # Check if install manifest exists
+    if [ -f "build/install_manifest.txt" ]; then
+        echo "Using install manifest to uninstall..."
+        # Read each line from manifest and remove the file
+        while IFS= read -r file; do
+            if [ -e "$file" ]; then
+                echo "Removing: $file"
+                sudo rm -f "$file"
+                
+                # Remove empty parent directories
+                dir=$(dirname "$file")
+                while [ "$dir" != "/" ]; do
+                    if rmdir "$dir" 2>/dev/null; then
+                        echo "Removed empty directory: $dir"
+                    else
+                        break
+                    fi
+                    dir=$(dirname "$dir")
+                done
+            fi
+        done < "build/install_manifest.txt"
+        
+        # Also remove common known files as backup
+        echo "Removing known installed files..."
+        sudo rm -f /usr/bin/kiot
+        sudo rm -f /etc/xdg/autostart/org.davidedmundson.kiot.desktop
+        sudo rm -f /usr/share/applications/org.davidedmundson.kiot.desktop
+        sudo rm -f /usr/share/kiot/activewindow_kwin.js
+        sudo rm -f /usr/lib/qt6/plugins/plasma/kcms/systemsettings/kcm_kiot.so
+        sudo rm -f /usr/share/applications/kcm_kiot.desktop
+        
+        # Remove empty directories
+        sudo rmdir /usr/share/kiot 2>/dev/null || true
+        
+        echo "Uninstall completed!"
+    else
+        echo "Install manifest not found. Removing known files..."
+        # Manual removal if manifest doesn't exist
+        sudo rm -f /usr/bin/kiot
+        sudo rm -f /etc/xdg/autostart/org.davidedmundson.kiot.desktop
+        sudo rm -f /usr/share/applications/org.davidedmundson.kiot.desktop
+        sudo rm -f /usr/share/kiot/activewindow_kwin.js
+        sudo rm -f /usr/lib/qt6/plugins/plasma/kcms/systemsettings/kcm_kiot.so
+        sudo rm -f /usr/share/applications/kcm_kiot.desktop
+        
+        # Remove empty directories
+        sudo rmdir /usr/share/kiot 2>/dev/null || true
+        
+        echo "Uninstall completed (manual mode)!"
+    fi
+    
+    # Update desktop database
+    echo "Updating desktop database..."
+    sudo update-desktop-database 2>/dev/null || true
+}
+
+while true; do
+    echo "======================================="
+    echo " KIOT Native Installer Menu"
+    echo "======================================="
+    echo
+    echo "0 Quit (runs cleanup before closing)"
+    echo "1 Build kiot"
+    echo "2 Install kiot (use 1 first, this requires sudo)"
+    echo "3 Build and install kiot (AIO, this requires sudo)"
+    echo "4 Uninstall (requires sudo, this will remove all file)"
+    echo "5 Cleanup (Deletes the build folder)"
+    echo
+    echo "======================================="
+    read -rp "Select an option: " choice
+
+    case "$choice" in
+        0)
+            cleanup
+            echo "Exiting."
+            exit 0
+            ;;
+        1)
+            build
+            pause
+            ;;
+        2)
+            echo "Installing kiot"
+            install
+            pause
+            ;;
+        3)
+            echo "Building and installing kiot..."
+            build_and_install
+            pause
+            ;;
+        4)
+            echo "Uninstalling kiot"
+            uninstall
+            pause
+            ;;
+        5)
+            echo "Cleaning up after us"
+            cleanup
+            pause
+            ;;
+        *)
+            echo "Invalid option. Please try again."
+            pause
+            ;;
+    esac
+done

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,0 +1,59 @@
+# Helper Scripts for Kiot
+
+This directory contains helper scripts to simplify Kiot installation and development.
+
+## Recommended Usage
+
+The easiest way to use these scripts is via the top-level **`helper.sh`** menu in the repository root:
+
+```bash
+chmod +x helper.sh
+./helper.sh
+```
+## Available Scripts
+
+### `dependencies.sh`
+Installs all required dependencies for your Linux distribution.
+- Detects package manager (apt/pacman)
+- Installs Qt6, KDE Frameworks 6, and system libraries
+
+
+### `native.sh`
+Interactive menu for native installation (using `make install`).
+- Build Kiot from source
+- Install system-wide
+- Uninstall previously installed versions
+- Clean build directory
+
+### `flatpak.sh`  
+Interactive menu for Flatpak installation.
+- Build Flatpak bundle
+- Install as user or system
+- Uninstall Flatpak version
+- Clean build artifacts
+
+## Usage
+
+1. Make scripts executable:
+   ```bash
+   chmod +x scripts/*.sh
+   ```
+
+2. Install dependencies:
+   ```bash
+   ./scripts/dependencies.sh
+   ```
+
+3. Choose installation method:
+   ```bash
+   # For native installation
+   ./scripts/native.sh
+   
+   # For Flatpak installation
+   ./scripts/flatpak.sh
+   ```
+
+## Notes
+- The `native.sh` script requires `sudo` for installation
+- The `flatpak.sh` script can install without `sudo` using `--user` flag
+- Dependencies may vary between distributions


### PR DESCRIPTION
#### **Summary**

This PR introduces a set of developer helper scripts inside a dedicated `scripts/` directory, along with a toplevel `helper.sh` menu. 

The goal is to simplify the onboarding process for new contributors and streamline building, installing, and testing KIOT across different Linux distributions and formats (Native and Flatpak).

---

### **Key Changes**

* **`helper.sh` (Repository Root):** An interactive terminal menu providing a single entry point for setting up dependencies and building the project. Includes defensive checks for missing scripts/directories.
* **`scripts/dependencies.sh`:** Auto-detects the host system's package manager (`pacman`, `apt`) and installs required Qt6, KDE Frameworks 6, and build tools.
* **`scripts/native.sh`:** Interactive wrapper for CMake builds. Handles standard build routines, system installations via manifest, uninstallation, and build directory cleanups.
* **`scripts/flatpak.sh`:** Simplifies local Flatpak development. Builds and packages the local bundle, installs it under `--user`, handles uninstallation, and dynamically parses the `app-id` directly from `.flatpak-manifest.yaml`.
* **`scripts/README.md`:** Brief documentation on how to run the scripts individually or via `helper.sh`.
* **`README.md` (Repository Root):** Updated setup and Flatpak build instructions with linkable navigation anchors for both quick helper execution and manual setup routines.
---

### **Impact & Safety**

* **Zero changes to source code:** Touches no core logic, CMake configuration, or existing repository files.
* **Defensive execution:** All scripts switch their working directory to the project root on execution, ensuring they run safely regardless of where they are invoked in the terminal.

---

### **Testing Completed**

* [x] Verified system dependency installation on CachyOS (`pacman`).
* [x] Completed a full native CMake build (`100%` target completion, including `kcm_kiot.so`).
* [x] Successfully verified Flatpak bundle builds via `flatpak-builder`.
* [x] Confirmed cleanup routines for both native build folders and Flatpak build artifacts.